### PR TITLE
Added missing add_instance string

### DIFF
--- a/lang/ca/block_rgrade.php
+++ b/lang/ca/block_rgrade.php
@@ -9,3 +9,5 @@ $string['error_saving_grade'] = 'S\'ha produït un error i no s\'ha pogut salvar
 $string['alert_units_table'] = "Les dades que es visualitzen corresponen a les de les dues darreres unitats per a les quals hi ha hagut activitat. Per a seleccionar-ne una/es altra/es, cal usar el selector d'unitats.";
 $string['alert_units_table_hide'] = "No vull tornar a veure l'avís.";
 $string['alert_units_table_ok'] = 'Accepta';
+
+$string['rgrade:addinstance'] = 'Afegeix un bloc nou de Qualificacions de continguts remots';

--- a/lang/en/block_rgrade.php
+++ b/lang/en/block_rgrade.php
@@ -9,3 +9,5 @@ $string['error_saving_grade'] = 'There was an error and failed to save the user 
 $string['alert_units_table'] = "The data displayed correspond to the last two units for which there has been activity. To select other use the units selector.";
 $string['alert_units_table_hide'] = "I don't want to see the notice again.";
 $string['alert_units_table_ok'] = 'Accept';
+
+$string['rgrade:addinstance'] = 'Add a new remote contents\' grades block';

--- a/lang/es/block_rgrade.php
+++ b/lang/es/block_rgrade.php
@@ -9,3 +9,5 @@ $string['error_saving_grade'] = 'Ha ocurrido un error y no se ha podido salvar e
 $string['alert_units_table'] = "Los datos que se visualizan corresponden a los de las dos últimas unidades para las que ha habido actividad. Para seleccionar una/s otra/s, hay que usar el selector de unidades.";
 $string['alert_units_table_hide'] = "No quiero volver a ver el aviso.";
 $string['alert_units_table_ok'] = 'Acepta';
+
+$string['rgrade:addinstance'] = 'Añadir un nuevo bloque de Calificaciones de contenidos remotos';


### PR DESCRIPTION
Added missing add_instance string to avoid following message when entering to **Course | Users | Permissions**:

`Invalid get_string() identifier: 'rgrade:addinstance' or component 'block_rgrade'. Perhaps you are missing $string['rgrade:addinstance'] = ''; in /dades/agora/html/moodle2/blocks/rgrade/lang/en/block_rgrade.php`
